### PR TITLE
Create snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: cointop
+version: master
+version-script: git -C parts/cointop/build rev-parse --short HEAD
+summary: Coin tracking for hackers
+description: |
+  cointop is a fast command-line interface application for viewing
+  cryptocurrency stats and information in your terminal. The interface
+  is inspired by htop. 
+
+grade: stable
+confinement: strict
+
+parts:
+  go:
+    source-tag: go1.9.4
+  cointop:
+    after: [go]
+    source: .
+    plugin: go
+    go-importpath: github.com/miguelmota/cointop
+
+apps:
+  cointop:
+    command: cointop
+    plugs:
+      - network
+      - network-bind


### PR DESCRIPTION
Adds snapcraft.yaml to enable building snaps of cointop.

Once landed there's a few steps to hand this over to you in the store.

* You should sign up for a snap store account at https://dashboard.snapcraft.io/
* On the forum, start a thread to request the transfer of ownership of cointop from me (snapcrafters) to you
* Once transferred, go to our build service https://build.snapcraft.io/ and login using github. Add your cointop repo, give it the registered snap name 'cointop' and it will start building

That will get builds on each commit pushed to the edge channel in the store.

As you haven't done any stable releases yet, I've just been doing basic shakedown test of the build in edge and then promoting it to the stable channel periodically. This is done via the dashboard at https://dashboard.snapcraft.io/snaps/cointop/revisions/

Alternatively on your mac you can `brew install snapcraft` and `snapcraft login` to the store and then `snapcraft release cointop <revno> <channelname` to release directly from your terminal.

If you have any questions, I'm happy to answer them here, or use the forum linked above.