### PR TITLE
use standard config dir path

### DIFF
--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -137,8 +138,15 @@ type APIKeys struct {
 	cmc string
 }
 
-var defaultConfigPath = "~/.cointop/config.toml"
 var defaultColorscheme = "cointop"
+
+func defaultConfigPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cointop", "config.toml"), nil
+}
 
 // NewCointop initializes cointop
 func NewCointop(config *Config) (*Cointop, error) {
@@ -147,7 +155,11 @@ func NewCointop(config *Config) (*Cointop, error) {
 		debug = true
 	}
 
-	configFilepath := defaultConfigPath
+	configFilepath, err := defaultConfigPath()
+	if err != nil {
+		return nil, err
+	}
+
 	if config != nil {
 		if config.ConfigFilepath != "" {
 			configFilepath = config.ConfigFilepath
@@ -202,7 +214,7 @@ func NewCointop(config *Config) (*Cointop, error) {
 		},
 	}
 
-	err := ct.setupConfig()
+	err = ct.setupConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello,

I was upgrading my setup with a new OS. And I had to copy every config file that were in ~, but I didn't want to copy everything in my ~.
I saw a `.cointop` hanging there and I kept it on the side as a reminder to propose this suggestion to move it to new standard of config dir. So in the future, I could just copy my ~/.config instead of cherry-picking through hundreds of dot files (I don't want to keep `.cache` for example)
