### PR TITLE
Fix #57: Add flag for config directory vs home directory

### DIFF
--- a/cointop/common/pathutil/pathutil.go
+++ b/cointop/common/pathutil/pathutil.go
@@ -3,22 +3,15 @@ package pathutil
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
 // UserPreferredHomeDir returns the preferred home directory for the user
 func UserPreferredHomeDir() (string, bool) {
-	var home string
 	var isConfigDir bool
 
-	if runtime.GOOS == "windows" {
-		home = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		isConfigDir = false
-	} else if runtime.GOOS == "linux" {
-		home = os.Getenv("XDG_CONFIG_HOME")
-		isConfigDir = true
-	}
+	home, _ := os.UserConfigDir()
+	isConfigDir = true
 
 	if home == "" {
 		home, _ = os.UserHomeDir()

--- a/cointop/common/pathutil/pathutil.go
+++ b/cointop/common/pathutil/pathutil.go
@@ -8,27 +8,35 @@ import (
 )
 
 // UserPreferredHomeDir returns the preferred home directory for the user
-func UserPreferredHomeDir() string {
+func UserPreferredHomeDir() (string, bool) {
 	var home string
+	var isConfigDir bool
 
 	if runtime.GOOS == "windows" {
 		home = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		isConfigDir = false
 	} else if runtime.GOOS == "linux" {
 		home = os.Getenv("XDG_CONFIG_HOME")
+		isConfigDir = true
 	}
 
 	if home == "" {
 		home, _ = os.UserHomeDir()
+		isConfigDir = false
 	}
 
-	return home
+	return home, isConfigDir
 }
 
 // NormalizePath normalizes and extends the path string
 func NormalizePath(path string) string {
 	// expand tilde
 	if strings.HasPrefix(path, "~/") {
-		path = filepath.Join(UserPreferredHomeDir(), path[2:])
+		home, isConfigDir := UserPreferredHomeDir()
+		if !isConfigDir {
+			path = filepath.Join(home, path[2:])
+		}
+		path = filepath.Join(home, path[10:])
 	}
 
 	path = strings.Replace(path, "/", string(filepath.Separator), -1)

--- a/cointop/common/pathutil/pathutil_test.go
+++ b/cointop/common/pathutil/pathutil_test.go
@@ -8,13 +8,22 @@ import (
 
 // TestNormalizePath checks that NormalizePath returns the correct directory
 func TestNormalizePath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	configDir, _ := os.UserConfigDir()
 	cases := []struct {
 		in, want string
 	}{
-		{"~/.config/cointop/config.toml", filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "/cointop/config.toml")},
+		{"~/.config/cointop/config.toml", filepath.Join(configDir, "/cointop/config.toml")},
+		{"~/.config/cointop/config.toml", filepath.Join(home, ".config/cointop/config.toml")},
+		{"~/.config/cointop/config.toml", filepath.Join(configDir, "/cointop/config.toml")},
+		{"~/.config/cointop/config.toml", filepath.Join(home, ".config/cointop/config.toml")},
 	}
-	for _, c := range cases {
+	for i, c := range cases {
 		got := NormalizePath(c.in)
+		if i > 1 {
+			home = ""
+			configDir = ""
+		}
 		if got != c.want {
 			t.Errorf("NormalizePath(%q) == %q, want %q", c.in, got, c.want)
 		}

--- a/cointop/common/pathutil/pathutil_test.go
+++ b/cointop/common/pathutil/pathutil_test.go
@@ -15,15 +15,9 @@ func TestNormalizePath(t *testing.T) {
 	}{
 		{"~/.config/cointop/config.toml", filepath.Join(configDir, "/cointop/config.toml")},
 		{"~/.config/cointop/config.toml", filepath.Join(home, ".config/cointop/config.toml")},
-		{"~/.config/cointop/config.toml", filepath.Join(configDir, "/cointop/config.toml")},
-		{"~/.config/cointop/config.toml", filepath.Join(home, ".config/cointop/config.toml")},
 	}
-	for i, c := range cases {
+	for _, c := range cases {
 		got := NormalizePath(c.in)
-		if i > 1 {
-			home = ""
-			configDir = ""
-		}
 		if got != c.want {
 			t.Errorf("NormalizePath(%q) == %q, want %q", c.in, got, c.want)
 		}

--- a/cointop/common/pathutil/pathutil_test.go
+++ b/cointop/common/pathutil/pathutil_test.go
@@ -1,0 +1,22 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNormalizePath checks that NormalizePath returns the correct directory
+func TestNormalizePath(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"~/.config/cointop/config.toml", filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "/cointop/config.toml")},
+	}
+	for _, c := range cases {
+		got := NormalizePath(c.in)
+		if got != c.want {
+			t.Errorf("NormalizePath(%q) == %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Changes:

- Changed UserPreferredHomeDir to return a string and a bool where the bool signifies if the returned string points to the user's config directory
- Remove runtime OS checks in favor of platform-agnostic functions like `os.UserHomeDir()` and `os.UserConfigDir()` to get the path to normalize
- Update NormalizePath to take into account if `home` is a config directory or not
- Add tests to make sure that the config directory is being placed correctly

## Notes:

- The proposed changes (as well as the original code) doesn't take into account what to do if the environment variable for the user's home directory is not defined (ie on Linux `os.UserHomeDir()` returns "")