### PR TITLE
Fix version Regex in Binary install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=$(curl --silent "https://api.github.com/repos/miguelmota/cointop/releases/latest" | grep -Po --color=never '"tag_name": "\K.*?(?=")')
+VERSION=$(curl --silent "https://api.github.com/repos/miguelmota/cointop/releases/latest" | grep -Po --color=never '"tag_name": ".\K.*?(?=")')
 
 OSNAME="linux"
 if [[ $(uname) == 'Darwin' ]]; then
@@ -9,7 +9,7 @@ fi
 
 (
   cd /tmp
-  wget https://github.com/miguelmota/cointop/releases/download/${VERSION}/cointop_${VERSION}_${OSNAME}_amd64.tar.gz
+  wget https://github.com/miguelmota/cointop/releases/download/v${VERSION}/cointop_${VERSION}_${OSNAME}_amd64.tar.gz
   tar -xvzf cointop_${VERSION}_${OSNAME}_amd64.tar.gz cointop
 
   sudo mv cointop /usr/local/bin/cointop


### PR DESCRIPTION
Previous regex was including the "v" in the query, causing the release links to 404, since the filenames in the releases do not contain the "v".