### PR TITLE
Migrate to building on for core20

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,24 +1,25 @@
 name: cointop
-version: master
-version-script: git -C parts/cointop/build rev-parse --short HEAD
+adopt-info: cointop
 summary: Interactive terminal based UI application for tracking cryptocurrencies
 description: |
   cointop is a fast and lightweight interactive terminal based UI application for tracking and monitoring cryptocurrency coin stats in real-time.
 grade: stable
 confinement: strict
+base: core20
 
 parts:
-  go:
-    source-tag: go1.14
   cointop:
-    after: [go]
     source: .
     plugin: go
-    go-importpath: github.com/miguelmota/cointop
+    build-packages:
+      - git
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version $(git rev-parse --short HEAD)
 
 apps:
   cointop:
-    command: cointop
+    command: bin/cointop
     plugs:
       - network
       - network-bind


### PR DESCRIPTION
Hi!
This PR updates the snap build configuration. Previously with no `base` specified it was building against an older Ubuntu base of 16.04. By specifying `core20` as the base, we get newer packages to build with, including newer go, which simplifies the parts. The newer `base` also triggers newer code path in `snapcraft`. 

I tested this on my local machine. All works as expected.

The only regression from doing this is that you'll no longer get i386 builds as i386 is no longer supported on Ubuntu 20.04 (the base from which core20 derives). If that's important we could go to `core18` instead.