### PR TITLE
Formatting numeric and monetary values according to user's locale

### DIFF
--- a/cointop/coins_table.go
+++ b/cointop/coins_table.go
@@ -120,7 +120,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 						Text:        symbol,
 					})
 			case "price":
-				text := humanize.Commaf(coin.Price)
+				text := humanize.Monetaryf(coin.Price, 2)
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -132,7 +132,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 						Text:        text,
 					})
 			case "24h_volume":
-				text := humanize.Commaf(coin.Volume24H)
+				text := humanize.Monetaryf(coin.Volume24H, 0)
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -151,7 +151,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 				if coin.PercentChange1H < 0 {
 					color1h = ct.colorscheme.TableColumnChangeDown
 				}
-				text := fmt.Sprintf("%.2f%%", coin.PercentChange1H)
+				text := fmt.Sprintf("%v%%", humanize.Numericf(coin.PercentChange1H, 2))
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -170,7 +170,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 				if coin.PercentChange24H < 0 {
 					color24h = ct.colorscheme.TableColumnChangeDown
 				}
-				text := fmt.Sprintf("%.2f%%", coin.PercentChange24H)
+				text := fmt.Sprintf("%v%%", humanize.Numericf(coin.PercentChange24H, 2))
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -189,7 +189,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 				if coin.PercentChange7D < 0 {
 					color7d = ct.colorscheme.TableColumnChangeDown
 				}
-				text := fmt.Sprintf("%.2f%%", coin.PercentChange7D)
+				text := fmt.Sprintf("%v%%", humanize.Numericf(coin.PercentChange7D, 2))
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -208,7 +208,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 				if coin.PercentChange30D < 0 {
 					color30d = ct.colorscheme.TableColumnChangeDown
 				}
-				text := fmt.Sprintf("%.2f%%", coin.PercentChange30D)
+				text := fmt.Sprintf("%v%%", humanize.Numericf(coin.PercentChange30D, 2))
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -220,7 +220,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 						Text:        text,
 					})
 			case "market_cap":
-				text := humanize.Commaf(coin.MarketCap)
+				text := humanize.Monetaryf(coin.MarketCap, 0)
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -232,7 +232,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 						Text:        text,
 					})
 			case "total_supply":
-				text := humanize.Commaf(coin.TotalSupply)
+				text := humanize.Numericf(coin.TotalSupply, 0)
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,
@@ -244,7 +244,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 						Text:        text,
 					})
 			case "available_supply":
-				text := humanize.Commaf(coin.AvailableSupply)
+				text := humanize.Numericf(coin.AvailableSupply, 0)
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells,

--- a/cointop/marketbar.go
+++ b/cointop/marketbar.go
@@ -35,10 +35,10 @@ func (ct *Cointop) UpdateMarketbar() error {
 	if ct.IsPortfolioVisible() {
 		ct.State.marketBarHeight = 1
 		total := ct.GetPortfolioTotal()
-		totalstr := humanize.Commaf(total)
+		totalstr := humanize.Monetaryf(total, 2)
 		if !(ct.State.currencyConversion == "BTC" || ct.State.currencyConversion == "ETH" || total < 1) {
 			total = math.Round(total*1e2) / 1e2
-			totalstr = humanize.Commaf2(total)
+			totalstr = humanize.Monetaryf(total, 2)
 		}
 
 		timeframe := ct.State.selectedChartRange
@@ -149,9 +149,9 @@ func (ct *Cointop) UpdateMarketbar() error {
 		content = fmt.Sprintf(
 			"%sGlobal ▶ Market Cap: %s %s 24H Volume: %s %s BTC Dominance: %.2f%%",
 			chartInfo,
-			fmt.Sprintf("%s%s", ct.CurrencySymbol(), humanize.Commaf0(market.TotalMarketCapUSD)),
+			fmt.Sprintf("%s%s", ct.CurrencySymbol(), humanize.Monetaryf(market.TotalMarketCapUSD, 0)),
 			separator1,
-			fmt.Sprintf("%s%s", ct.CurrencySymbol(), humanize.Commaf0(market.Total24HVolumeUSD)),
+			fmt.Sprintf("%s%s", ct.CurrencySymbol(), humanize.Monetaryf(market.Total24HVolumeUSD, 0)),
 			separator2,
 			market.BitcoinPercentageOfMarketCap,
 		)

--- a/cointop/portfolio.go
+++ b/cointop/portfolio.go
@@ -125,7 +125,7 @@ func (ct *Cointop) GetPortfolioTable() *table.Table {
 						Text:        symbol,
 					})
 			case "price":
-				text := humanize.Commaf(coin.Price)
+				text := humanize.Monetaryf(coin.Price, 2)
 				symbolPadding := 1
 				ct.SetTableColumnWidth(header, utf8.RuneCountInString(text)+symbolPadding)
 				ct.SetTableColumnAlignLeft(header, false)
@@ -150,7 +150,7 @@ func (ct *Cointop) GetPortfolioTable() *table.Table {
 						Text:        text,
 					})
 			case "balance":
-				text := humanize.Commaf(coin.Balance)
+				text := humanize.Monetaryf(coin.Balance, 2)
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				colorBalance := ct.colorscheme.TableColumnPrice
@@ -675,11 +675,11 @@ func (ct *Cointop) PrintHoldingsTable(options *TablePrintOptions) error {
 			records[i] = []string{
 				entry.Name,
 				entry.Symbol,
-				fmt.Sprintf("%s%s", symbol, humanize.Commaf(entry.Price)),
-				humanize.Commaf(entry.Holdings),
-				fmt.Sprintf("%s%s", symbol, humanize.Commaf(entry.Balance)),
-				fmt.Sprintf("%.2f%%", entry.PercentChange24H),
-				fmt.Sprintf("%.2f%%", percentHoldings),
+				fmt.Sprintf("%s%s", symbol, humanize.Monetaryf(entry.Price, 2)),
+				humanize.Numericf(entry.Holdings, 2),
+				fmt.Sprintf("%s%s", symbol, humanize.Monetaryf(entry.Balance, 2)),
+				humanize.Numericf(entry.PercentChange24H, 2),
+				humanize.Numericf(percentHoldings, 2),
 			}
 		} else {
 			records[i] = []string{
@@ -785,7 +785,7 @@ func (ct *Cointop) PrintTotalHoldings(options *TablePrintOptions) error {
 	value := strconv.FormatFloat(total, 'f', -1, 64)
 
 	if humanReadable {
-		value = fmt.Sprintf("%s%s", symbol, humanize.Commaf(total))
+		value = fmt.Sprintf("%s%s", symbol, humanize.Monetaryf(total, 2))
 	}
 
 	if format == "csv" {

--- a/cointop/price.go
+++ b/cointop/price.go
@@ -69,7 +69,7 @@ func GetCoinPrices(config *PricesConfig) ([]string, error) {
 		}
 
 		symbol := CurrencySymbol(config.Currency)
-		value := fmt.Sprintf("%s%s", symbol, humanize.Commaf(price))
+		value := fmt.Sprintf("%s%s", symbol, humanize.Monetaryf(price, 2))
 		prices = append(prices, value)
 	}
 

--- a/cointop/price_alerts.go
+++ b/cointop/price_alerts.go
@@ -96,7 +96,7 @@ func (ct *Cointop) GetPriceAlertsTable() *table.Table {
 				})
 
 			case "target_price":
-				targetPrice := fmt.Sprintf("%s %s", entry.Operator, humanize.Commaf(entry.TargetPrice))
+				targetPrice := fmt.Sprintf("%s %s", entry.Operator, humanize.Monetaryf(entry.TargetPrice, 2))
 				ct.SetTableColumnWidthFromString(header, targetPrice)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells, &table.RowCell{
@@ -107,7 +107,7 @@ func (ct *Cointop) GetPriceAlertsTable() *table.Table {
 					Text:        targetPrice,
 				})
 			case "price":
-				text := humanize.Commaf(coin.Price)
+				text := humanize.Monetaryf(coin.Price, 2)
 				ct.SetTableColumnWidthFromString(header, text)
 				ct.SetTableColumnAlignLeft(header, false)
 				rowCells = append(rowCells, &table.RowCell{
@@ -187,7 +187,7 @@ func (ct *Cointop) CheckPriceAlert(alert *PriceAlert) error {
 	}
 	var msg string
 	title := "Cointop Alert"
-	priceStr := fmt.Sprintf("%s%s (%s%s)", ct.CurrencySymbol(), humanize.Commaf(alert.TargetPrice), ct.CurrencySymbol(), humanize.Commaf(coin.Price))
+	priceStr := fmt.Sprintf("%s%s (%s%s)", ct.CurrencySymbol(), humanize.Numericf(alert.TargetPrice, 2), ct.CurrencySymbol(), humanize.Monetaryf(coin.Price, 2))
 	if alert.Operator == ">" {
 		if coin.Price > alert.TargetPrice {
 			msg = fmt.Sprintf("%s price is greater than %v", alert.CoinName, priceStr)

--- a/go.mod
+++ b/go.mod
@@ -27,3 +27,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/miguelmota/cointop/pkg/humanize => ./pkg/humanize

--- a/go.mod
+++ b/go.mod
@@ -27,5 +27,3 @@ require (
 )
 
 go 1.13
-
-replace github.com/miguelmota/cointop/pkg/humanize => ./pkg/humanize

--- a/pkg/table/align/align.go
+++ b/pkg/table/align/align.go
@@ -3,35 +3,39 @@ package align
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // AlignLeft align left
 func AlignLeft(s string, n int) string {
-	if len(s) > n {
+	slen := utf8.RuneCountInString(s)
+	if slen > n {
 		return s[:n]
 	}
 
-	return fmt.Sprintf("%s%s", s, strings.Repeat(" ", n-len(s)))
+	return fmt.Sprintf("%s%s", s, strings.Repeat(" ", n-slen))
 }
 
 // AlignRight align right
 func AlignRight(s string, n int) string {
-	if len(s) > n {
+	slen := utf8.RuneCountInString(s)
+	if slen > n {
 		return s[:n]
 	}
 
-	return fmt.Sprintf("%s%s", strings.Repeat(" ", n-len(s)), s)
+	return fmt.Sprintf("%s%s", strings.Repeat(" ", n-slen), s)
 }
 
 // AlignCenter align center
 func AlignCenter(s string, n int) string {
-	if len(s) > n {
+	slen := utf8.RuneCountInString(s)
+	if slen > n {
 		return s[:n]
 	}
 
-	pad := (n - len(s)) / 2
+	pad := (n - slen) / 2
 	lpad := pad
-	rpad := n - len(s) - lpad
+	rpad := n - slen - lpad
 
 	return fmt.Sprintf("%s%s%s", strings.Repeat(" ", lpad), s, strings.Repeat(" ", rpad))
 }

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/miguelmota/cointop/pkg/pad"
 	"github.com/miguelmota/cointop/pkg/table/align"
@@ -129,7 +130,7 @@ func (t *Table) normalizeColWidthPerc() {
 // Format format table
 func (t *Table) Format() *Table {
 	for _, c := range t.cols {
-		c.width = len(c.name) + 1
+		c.width = utf8.RuneCountInString(c.name) + 1
 		if c.minWidth > c.width {
 			c.width = c.minWidth
 		}
@@ -151,8 +152,9 @@ func (t *Table) Format() *Table {
 				r.strValues[j] = fmt.Sprintf("%v", v)
 			}
 
-			if len(r.strValues[j]) > t.cols[j].width {
-				t.cols[j].width = len(r.strValues[j])
+			runeCount := utf8.RuneCountInString(r.strValues[j])
+			if runeCount > t.cols[j].width {
+				t.cols[j].width = runeCount
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds support to format numbers using locales specified in the `LC_NUMERIC` and `LC_MONETARY` environment variables via [`x/text/message` printer](https://pkg.go.dev/golang.org/x/text/message#example-Printer-Numbers).

In order to properly format numbers according to their meaning, i.e. number (e.g. `1h_change`) or currency (e.g. `price`) the `Comma*f` functions have been replaced with custom `Numericf` and `Monetaryf` functions.

To test run: `LC_NUMERIC=bn LC_MONETARY=de-CH go run .`, which will display currency in a Swiss German format and numbers in Bengali. This will allow people to view the cointop numeric and monetary values in their favourite format:

```
   ▲[r]ank  [n]ame            [s]ymbol     €[p]rice   [1]H%   [2]4H%    [7]D%       24H [v]olume       [m]arket cap   [a]vailable supply     [t]otal supply   last [u]pdated
  *     1   Bitcoin           BTC        467’864.00  -০.৮৭%   -৮.২৬%   -৮.৬৫%    814’660’896’107  8’748’772’383’916          ১,৮৬,৮৫,৬৭৫        ২,১০,০০,০০০  17:34:53 Apr 18
  *     2   Ethereum          ETH         18’098.44  -০.৩৭%   -৯.৩১%   -১.০৯%    484’690’957’067  2’092’856’791’162         ১১,৫৫,২০,৮৭৯       ১১,৫৫,২০,৮৭৯  17:35:12 Apr 18
        3   Binance Coin      BNB          3’946.54   ১.৬৭%   -৯.৪৪%   -২.০৫%     63’228’874’268    610’341’951’978         ১৫,৪৫,৩৩,৬৫১       ১৭,০৫,৩৩,৬৫১  17:34:44 Apr 18
        4   XRP               XRP             11.26   ০.৬৪%  -১৫.৮০%   -৩.৮৫%    152’030’449’415    515’275’538’063      ৪৫,৯৭,৩৩,১৮,০৫৬  ১,০০,০০,০০,০০,০০০  17:35:59 Apr 18
        5   Tether            USDT             8.46  -০.০২%    ০.৪৫%   -০.৯১%  1’831’827’779’717    407’461’927’782      ৪৮,১৮,৭১,৯১,৪৯৯    ৪৮,১৮,৭১,৯১,৪৯৯  17:06:52 Apr 18
        6   Dogecoin          DOGE             2.61  -১.৫০%   ১৮.৪৭%  ৩৭৯.৩৫%    200’643’707’551    340’692’607’772    ১,২৯,২৩,৭৯,৭১,৭১০  ১,২৯,২৩,৭৯,৭১,৭১০  17:35:04 Apr 18
```
        
        
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/16507/115151526-8220d000-a06d-11eb-98b8-4825cb89ff7c.png">
