### PR TITLE
Draft: Allow favourite indicator to be configured

### DIFF
--- a/cointop/coins_table.go
+++ b/cointop/coins_table.go
@@ -80,7 +80,7 @@ func (ct *Cointop) GetCoinsTable() *table.Table {
 			case "rank":
 				star := ct.colorscheme.TableRow(" ")
 				if coin.Favorite {
-					star = ct.colorscheme.TableRowFavorite("*")
+					star = ct.colorscheme.TableRowFavorite(ct.config.FavoriteChar)
 				}
 				rank := fmt.Sprintf("%s%v", star, ct.colorscheme.TableRow(fmt.Sprintf("%6v ", coin.Rank)))
 				ct.SetTableColumnWidth(header, 8)

--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -49,6 +49,7 @@ type State struct {
 
 	favorites                  map[string]bool
 	favoritesTableColumns      []string
+	favoriteChar               string
 	helpVisible                bool
 	hideMarketbar              bool
 	hideChart                  bool
@@ -147,6 +148,7 @@ type Config struct {
 	Colorscheme         string
 	ConfigFilepath      string
 	CoinMarketCapAPIKey string
+	FavoriteChar        string
 	NoPrompts           bool
 	HideMarketbar       bool
 	HideChart           bool
@@ -247,6 +249,7 @@ func NewCointop(config *Config) (*Cointop, error) {
 			marketBarHeight:       1,
 			maxPages:              int(maxPages),
 			onlyTable:             config.OnlyTable,
+			favoriteChar:          config.FavoriteChar,
 			refreshRate:           60 * time.Second,
 			selectedChartRange:    DefaultChartRange,
 			shortcutKeys:          DefaultShortcuts(),

--- a/cointop/config.go
+++ b/cointop/config.go
@@ -36,6 +36,7 @@ type config struct {
 	Portfolio     map[string]interface{} `toml:"portfolio"`
 	PriceAlerts   map[string]interface{} `toml:"price_alerts"`
 	Currency      interface{}            `toml:"currency"`
+	FavoriteChar  interface{}            `toml:"favorite_char"`
 	DefaultView   interface{}            `toml:"default_view"`
 	CoinMarketCap map[string]interface{} `toml:"coinmarketcap"`
 	API           interface{}            `toml:"api"`
@@ -252,6 +253,7 @@ func (ct *Cointop) configToToml() ([]byte, error) {
 	var defaultViewIfc interface{} = ct.State.defaultView
 	var colorschemeIfc interface{} = ct.colorschemeName
 	var refreshRateIfc interface{} = uint(ct.State.refreshRate.Seconds())
+	var favoriteCharIfc interface{} = ct.State.favoriteChar
 	var cacheDirIfc interface{} = ct.State.cacheDir
 
 	cmcIfc := map[string]interface{}{
@@ -290,6 +292,7 @@ func (ct *Cointop) configToToml() ([]byte, error) {
 		Currency:      currencyIfc,
 		DefaultView:   defaultViewIfc,
 		Favorites:     favoritesMapIfc,
+		FavoriteChar:  favoriteCharIfc,
 		RefreshRate:   refreshRateIfc,
 		Shortcuts:     shortcutsIfcs,
 		Portfolio:     portfolioIfc,


### PR DESCRIPTION
This is an incomplete draft PR exploring feasibility to make the favourite indicator character configurable. From tests the indicator character may not be properly persisted and be overwritten with and empty string.

Generally is this an addition you find useful? If yes, I'm happy to detail this out…