### PR TITLE
Format alert target price without exponent

### DIFF
--- a/cointop/price_alerts.go
+++ b/cointop/price_alerts.go
@@ -251,7 +251,8 @@ func (ct *Cointop) UpdatePriceAlertsUpdateMenu(isNew bool, coin *Coin) error {
 			if ok {
 				coin.Name = entry.CoinName
 				currentPrice = strconv.FormatFloat(coin.Price, 'f', -1, 64)
-				value = fmt.Sprintf("%s %v", entry.Operator, entry.TargetPrice)
+				targetPrice := strconv.FormatFloat(entry.TargetPrice, 'f', -1, 64)
+				value = fmt.Sprintf("%s %v", entry.Operator, targetPrice)
 				ct.State.priceAlertEditID = entry.ID
 				isEdit = true
 			}


### PR DESCRIPTION
When editing very small alert target prices the float value in the input field would be formatted with an exponent (scientific notation), which would not be parsed properly and result in an unintended input:

Given a very small alert target price: `0.00000155`
![image](https://user-images.githubusercontent.com/16507/115156929-19dee800-a087-11eb-9c61-b7a16b54b544.png)

When it is being edited it is formatted in scientific notation with an exponent:
![image](https://user-images.githubusercontent.com/16507/115156934-1e0b0580-a087-11eb-8012-59a5e10d0eb6.png)

Unfortunately the scientific notation is not supported as input and the exponent is discarded, changing the value of the target price significantly as the original value of `0.00000155` has changed to `1.55`:
![image](https://user-images.githubusercontent.com/16507/115156938-219e8c80-a087-11eb-8484-17364df6db76.png)
