### PR TITLE
Add support for :PREFERRED_CACHE_HOME:

### DIFF
--- a/pkg/pathutil/pathutil.go
+++ b/pkg/pathutil/pathutil.go
@@ -22,6 +22,22 @@ func UserPreferredConfigDir() string {
 	return config
 }
 
+// UserPreferredCacheDir returns the preferred cache directory for the user
+func UserPreferredCacheDir() string {
+	defaultCacheDir := "/tmp"
+
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return defaultCacheDir
+	}
+
+	if cache == "" {
+		return defaultCacheDir
+	}
+
+	return cache
+}
+
 // UserPreferredHomeDir returns the preferred home directory for the user
 func UserPreferredHomeDir() string {
 	home, err := os.UserHomeDir()
@@ -36,6 +52,7 @@ func UserPreferredHomeDir() string {
 func NormalizePath(path string) string {
 	userHome := UserPreferredHomeDir()
 	userConfigHome := UserPreferredConfigDir()
+	userCacheHome := UserPreferredCacheDir()
 
 	// expand tilde
 	if strings.HasPrefix(path, "~/") {
@@ -44,6 +61,7 @@ func NormalizePath(path string) string {
 
 	path = strings.Replace(path, ":HOME:", userHome, -1)
 	path = strings.Replace(path, ":PREFERRED_CONFIG_HOME:", userConfigHome, -1)
+	path = strings.Replace(path, ":PREFERRED_CACHE_HOME:", userCacheHome, -1)
 	path = strings.Replace(path, "/", string(filepath.Separator), -1)
 
 	return filepath.Clean(path)


### PR DESCRIPTION
This PR adds support `:PREFERRED_CACHE_HOME:` to config.toml path value parsing, so that when the following is set in `config.toml`: `cache_dir = ":PREFERRED_CACHE_HOME:/cointop"` the cache files are written to `~/Library/Caches/cointop` on macOS.

Additionally I see value in adding `/cointop` to the default and configured cache directory, unless the last path component is already `/cointop`, this makes it more clear where the cache files are coming from and allows to clear them more easily as over time many cache files are accumulated.