### PR TITLE
Improve debuglog

### DIFF
--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -101,6 +101,7 @@ type Cointop struct {
 	colorscheme     *Colorscheme
 	debug           bool
 	filecache       *filecache.FileCache
+	logfile         *os.File
 	forceRefresh    chan bool
 	limiter         <-chan time.Time
 	maxTableWidth   int
@@ -277,6 +278,9 @@ func NewCointop(config *Config) (*Cointop, error) {
 			Menu:        NewMenuView(),
 			Input:       NewInputView(),
 		},
+	}
+	if debug {
+		ct.initlog()
 	}
 
 	err := ct.SetupConfig()

--- a/cointop/debug.go
+++ b/cointop/debug.go
@@ -1,27 +1,25 @@
 package cointop
 
 import (
-	"fmt"
+	"log"
 	"os"
-	"time"
 )
 
-// debuglog writs a debug log to stdout
-func (ct *Cointop) debuglog(msg string) {
-	if !ct.debug {
-		return
-	}
-
+func (ct *Cointop) initlog() {
 	filename := "/tmp/cointop.log"
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		panic(err)
 	}
+	log.SetOutput(f)
+	ct.logfile = f
+}
 
-	defer f.Close()
-
-	text := fmt.Sprintf("%v %s\n", time.Now().Unix(), msg)
-	if _, err = f.WriteString(text); err != nil {
-		panic(err)
+// debuglog writes a debug log message to /tmp/cointop.log if the DEBUG environment is set.
+func (ct *Cointop) debuglog(fmt string, arg ...interface{}) {
+	if !ct.debug {
+		return
 	}
+
+	log.Printf(fmt+"\n", arg...)
 }

--- a/cointop/debug.go
+++ b/cointop/debug.go
@@ -16,10 +16,10 @@ func (ct *Cointop) initlog() {
 }
 
 // debuglog writes a debug log message to /tmp/cointop.log if the DEBUG environment is set.
-func (ct *Cointop) debuglog(fmt string, arg ...interface{}) {
+func (ct *Cointop) debuglog(format string, args ...interface{}) {
 	if !ct.debug {
 		return
 	}
 
-	log.Printf(fmt+"\n", arg...)
+	log.Printf(format+"\n", args...)
 }

--- a/cointop/navigation.go
+++ b/cointop/navigation.go
@@ -1,7 +1,6 @@
 package cointop
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -442,7 +441,7 @@ func (ct *Cointop) HighlightRow(pageRowIndex int) error {
 			cy = h - (l - pageRowIndex)
 		}
 	}
-	ct.debuglog(fmt.Sprintf("highlightRow idx:%v h:%v cy:%v oy:%v", pageRowIndex, h, cy, oy))
+	ct.debuglog("highlightRow idx:%v h:%v cy:%v oy:%v", pageRowIndex, h, cy, oy)
 	ct.Views.Table.SetOrigin(ox, oy)
 	ct.Views.Table.SetCursor(cx, cy)
 	return nil

--- a/cointop/portfolio.go
+++ b/cointop/portfolio.go
@@ -327,7 +327,7 @@ func (ct *Cointop) UpdatePortfolioUpdateMenu() error {
 	coin := ct.HighlightedRowCoin()
 	exists := ct.PortfolioEntryExists(coin)
 	value := strconv.FormatFloat(ct.CoinHoldings(coin), 'f', -1, 64)
-	ct.debuglog(fmt.Sprintf("holdings %v", value))
+	ct.debuglog("holdings %v", value)
 	var mode string
 	var current string
 	var submitText string

--- a/cointop/quit.go
+++ b/cointop/quit.go
@@ -6,8 +6,9 @@ import (
 	"github.com/miguelmota/gocui"
 )
 
-// Quit quites the program
+// Quit quits the program
 func (ct *Cointop) Quit() error {
+	ct.logfile.Close()
 	return gocui.ErrQuit
 }
 
@@ -28,6 +29,7 @@ func (ct *Cointop) QuitView() error {
 // Exit safely exits the program
 func (ct *Cointop) Exit() {
 	ct.debuglog("exit()")
+	ct.logfile.Close()
 	if ct.g != nil {
 		ct.g.Close()
 	} else {


### PR DESCRIPTION
* By using package [`log`](https://pkg.go.dev/log)
* Allowing to use format string and arguments, removing to `fmt.Sprintf()`, e.g. ~~`ct.debuglog(fmt.Sprintf("holdings %v", value))`~~ »  `ct.debuglog("holdings %v", value)`
* Opening and closing the logfile once per cointop run, instead of opening and closing it for every log message.