### PR TITLE
Naively account for differing length API returns for better portfolio charting.

### DIFF
--- a/cointop/chart.go
+++ b/cointop/chart.go
@@ -271,8 +271,6 @@ func (ct *Cointop) PortfolioChart() error {
 			sum := portfolio[i].Holdings * price
 			if (j + lenDelta) < baseLen {
 				data[j + lenDelta] += sum
-			} else {
-				data = append(data, sum)
 			}
 		}
 	}

--- a/cointop/chart.go
+++ b/cointop/chart.go
@@ -202,7 +202,7 @@ func (ct *Cointop) PortfolioChart() error {
 	start := nowseconds - int64(rangeseconds.Seconds())
 	end := nowseconds
 
-	var data []float64
+	var dataSlices [][]float64
 	portfolio := ct.GetPortfolioSlice()
 	chartname := ct.SelectedCoinName()
 	for _, p := range portfolio {
@@ -253,12 +253,24 @@ func (ct *Cointop) PortfolioChart() error {
 				}()
 			}
 		}
+		dataSlices = append(dataSlices, graphData)
+	}
 
-		for i := range graphData {
-			price := graphData[i]
-			sum := p.Holdings * price
-			if i < len(data) {
-				data[i] += sum
+	var baseLen int = 0
+	for i := range dataSlices {
+		if len(dataSlices[i]) > baseLen {
+			baseLen = len(dataSlices[i])
+		}
+	}
+
+	data := make([]float64, baseLen)
+	for i := range dataSlices {
+		lenDelta := baseLen - len(dataSlices[i])
+		for j := range dataSlices[i] {
+			price := dataSlices[i][j]
+			sum := portfolio[i].Holdings * price
+			if (j + lenDelta) < baseLen {
+				data[j + lenDelta] += sum
 			} else {
 				data = append(data, sum)
 			}


### PR DESCRIPTION
I noticed my portfolio graph was messed up at timescales where the assets I was tracking didn't exist yet. Instead of assuming that all of the API data returns were aligned by the first entry, I chose to assume that they were aligned on the last entry and if there were less data points in a slice than the largest returned API slice, I offset by the difference of those slices to get the effect of aligning the slices on the end value.