### PR TITLE
Hide chart portfolio value from Y-axis on charts, and remove 24h% change

### DIFF
--- a/cointop/chart.go
+++ b/cointop/chart.go
@@ -266,6 +266,16 @@ func (ct *Cointop) PortfolioChart() error {
 		}
 	}
 
+	// Scale Portfolio Balances to hide value
+	if ct.State.hidePortfolioBalances {
+		var lastPrice = data[len(data)-1]
+		if lastPrice > 0.0 {
+			for i, price := range data {
+				data[i] = 100 * price / lastPrice
+			}
+		}
+	}
+
 	chart.SetData(data)
 	ct.State.chartPoints = chart.GetChartPoints(maxX)
 

--- a/cointop/marketbar.go
+++ b/cointop/marketbar.go
@@ -71,6 +71,7 @@ func (ct *Cointop) UpdateMarketbar() error {
 			color24h = ct.colorscheme.MarketbarChangeDownSprintf()
 			arrow = "▼"
 		}
+		percentChange24Hstr := color24h(fmt.Sprintf("%.2f%%%s", percentChange24H, arrow))
 
 		chartInfo := ""
 		if !ct.State.hideChart {
@@ -84,13 +85,14 @@ func (ct *Cointop) UpdateMarketbar() error {
 		totalstr = fmt.Sprintf("%s%s", ct.CurrencySymbol(), totalstr)
 		if ct.State.hidePortfolioBalances {
 			totalstr = HiddenBalanceChars
+			percentChange24Hstr = HiddenBalanceChars
 		}
 
 		content = fmt.Sprintf(
 			"%sTotal Portfolio Value: %s • 24H: %s",
 			chartInfo,
 			ct.colorscheme.MarketBarLabelActive(totalstr),
-			color24h(fmt.Sprintf("%.2f%%%s", percentChange24H, arrow)),
+			percentChange24Hstr,
 		)
 	} else {
 		ct.State.marketBarHeight = 1

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -187,7 +187,7 @@ draft: false
 
   You can run cointop with the `--hide-portfolio-balances` flag to hide portfolio balances or use the keyboard shortcut <kbd>Ctrl</kbd>+<kbd>space</kbd> on the portfolio page to toggle hide/show.
 
-  <img width="880" alt="hide portfolio balances" src="https://user-images.githubusercontent.com/168240/133199691-f5ec0714-8c83-4df3-a525-5ccea1fcf931.png" />
+  <img width="880" alt="hide portfolio balances" src="https://user-images.githubusercontent.com/122371/133578568-153af3cc-350d-4744-ac89-dd8f5e317d1d.png" />
 
 ## I'm getting question marks or weird symbols instead of the correct characters.
 


### PR DESCRIPTION
Balance chart is scaled so that current value is "100", and the 24%change is removed as this can leak information about (relative) holdings in the portfolio.

<img width="1256" alt="Screen Shot 2021-09-17 at 8 07 35 am" src="https://user-images.githubusercontent.com/122371/133692071-076dc94b-4b79-4ec3-a2a9-525ebb3f11ee.png">
