### PR TITLE
#129 Allow configurable max_chart_width (default 175, if 0 use full width)

### DIFF
--- a/cointop/chart.go
+++ b/cointop/chart.go
@@ -453,7 +453,7 @@ func (ct *Cointop) ShowChartLoader() error {
 func (ct *Cointop) ChartWidth() int {
 	log.Debug("ChartWidth()")
 	w := ct.Width()
-	max := int(ct.config.MaxChartWidth.(int64))
+	max := ct.State.maxChartWidth
 	if max > 0 && w > max {
 		return max
 	}

--- a/cointop/chart.go
+++ b/cointop/chart.go
@@ -342,6 +342,10 @@ func (ct *Cointop) ShortenChart() error {
 	ct.State.chartHeight = candidate
 	ct.State.lastChartHeight = ct.State.chartHeight
 
+	if err := ct.Save(); err != nil {
+		return err
+	}
+
 	go ct.UpdateChart()
 	return nil
 }
@@ -355,6 +359,10 @@ func (ct *Cointop) EnlargeChart() error {
 	}
 	ct.State.chartHeight = candidate
 	ct.State.lastChartHeight = ct.State.chartHeight
+
+	if err := ct.Save(); err != nil {
+		return err
+	}
 
 	go ct.UpdateChart()
 	return nil

--- a/cointop/chart.go
+++ b/cointop/chart.go
@@ -453,8 +453,8 @@ func (ct *Cointop) ShowChartLoader() error {
 func (ct *Cointop) ChartWidth() int {
 	log.Debug("ChartWidth()")
 	w := ct.Width()
-	max := 175
-	if w > max {
+	max := int(ct.config.MaxChartWidth.(int64))
+	if max > 0 && w > max {
 		return max
 	}
 

--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -183,6 +183,9 @@ var DefaultChartRange = "1Y"
 // DefaultMaxChartWidth ...
 var DefaultMaxChartWidth int = 175
 
+// DefaultChartHeight ...
+var DefaultChartHeight int = 10
+
 // DefaultSortBy ...
 var DefaultSortBy = "rank"
 
@@ -274,8 +277,8 @@ func NewCointop(config *Config) (*Cointop, error) {
 				Entries: make(map[string]*PortfolioEntry),
 			},
 			portfolioTableColumns: DefaultPortfolioTableHeaders,
-			chartHeight:           10,
-			lastChartHeight:       10,
+			chartHeight:           DefaultChartHeight,
+			lastChartHeight:       DefaultChartHeight,
 			tableOffsetX:          0,
 			tableColumnWidths:     sync.Map{},
 			tableColumnAlignLeft:  sync.Map{},

--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -180,9 +180,6 @@ var DefaultCurrency = "USD"
 // DefaultChartRange ...
 var DefaultChartRange = "1Y"
 
-// DefaultMaxTableWidth ...
-var DefaultMaxTableWidth int = 175
-
 // DefaultMaxChartWidth ...
 var DefaultMaxChartWidth int = 175
 
@@ -237,7 +234,7 @@ func NewCointop(config *Config) (*Cointop, error) {
 		apiChoice:      CoinGecko,
 		apiKeys:        new(APIKeys),
 		forceRefresh:   make(chan bool),
-		maxTableWidth:  DefaultMaxTableWidth,
+		maxTableWidth:  175,
 		ActionsMap:     ActionsMap(),
 		cache:          cache.New(1*time.Minute, 2*time.Minute),
 		colorsDir:      config.ColorsDir,

--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -110,6 +110,7 @@ type Cointop struct {
 	forceRefresh    chan bool
 	limiter         <-chan time.Time
 	maxTableWidth   int
+	maxChartWidth   int
 	refreshMux      sync.Mutex
 	refreshTicker   *time.Ticker
 	saveMux         sync.Mutex
@@ -179,6 +180,12 @@ var DefaultCurrency = "USD"
 // DefaultChartRange ...
 var DefaultChartRange = "1Y"
 
+// DefaultMaxTableWidth ...
+var DefaultMaxTableWidth int = 175
+
+// DefaultMaxChartWidth ...
+var DefaultMaxChartWidth int = 175
+
 // DefaultSortBy ...
 var DefaultSortBy = "rank"
 
@@ -230,7 +237,8 @@ func NewCointop(config *Config) (*Cointop, error) {
 		apiChoice:      CoinGecko,
 		apiKeys:        new(APIKeys),
 		forceRefresh:   make(chan bool),
-		maxTableWidth:  175,
+		maxTableWidth:  DefaultMaxTableWidth,
+		maxChartWidth:  DefaultMaxChartWidth,
 		ActionsMap:     ActionsMap(),
 		cache:          cache.New(1*time.Minute, 2*time.Minute),
 		colorsDir:      config.ColorsDir,

--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -46,6 +46,7 @@ type State struct {
 	convertMenuVisible bool
 	defaultView        string
 	defaultChartRange  string
+	maxChartWidth      int
 
 	// DEPRECATED: favorites by 'symbol' is deprecated because of collisions.
 	favoritesBySymbol map[string]bool
@@ -110,7 +111,6 @@ type Cointop struct {
 	forceRefresh    chan bool
 	limiter         <-chan time.Time
 	maxTableWidth   int
-	maxChartWidth   int
 	refreshMux      sync.Mutex
 	refreshTicker   *time.Ticker
 	saveMux         sync.Mutex
@@ -238,7 +238,6 @@ func NewCointop(config *Config) (*Cointop, error) {
 		apiKeys:        new(APIKeys),
 		forceRefresh:   make(chan bool),
 		maxTableWidth:  DefaultMaxTableWidth,
-		maxChartWidth:  DefaultMaxChartWidth,
 		ActionsMap:     ActionsMap(),
 		cache:          cache.New(1*time.Minute, 2*time.Minute),
 		colorsDir:      config.ColorsDir,
@@ -253,6 +252,7 @@ func NewCointop(config *Config) (*Cointop, error) {
 			coinsTableColumns:  DefaultCoinTableHeaders,
 			currencyConversion: DefaultCurrency,
 			defaultChartRange:  DefaultChartRange,
+			maxChartWidth:      DefaultMaxChartWidth,
 			// DEPRECATED: favorites by 'symbol' is deprecated because of collisions. Kept for backward compatibility.
 			favoritesBySymbol:     make(map[string]bool),
 			favorites:             make(map[string]bool),

--- a/cointop/config.go
+++ b/cointop/config.go
@@ -304,7 +304,6 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 	chartMapIfc := map[string]interface{}{}
 	chartMapIfc["max_width"] = ct.State.maxChartWidth
 	chartMapIfc["height"] = ct.State.chartHeight
-	log.Debugf("XXX chart = %s", chartMapIfc)
 
 	var inputs = &ConfigFileConfig{
 		API:               apiChoiceIfc,
@@ -359,6 +358,7 @@ func (ct *Cointop) loadChartConfig() error {
 	chartHeightIfc, ok := ct.config.Chart["height"]
 	if ok {
 		ct.State.chartHeight = int(chartHeightIfc.(int64))
+		ct.State.lastChartHeight = ct.State.chartHeight
 	}
 	return nil
 }

--- a/cointop/config.go
+++ b/cointop/config.go
@@ -42,6 +42,8 @@ type ConfigFileConfig struct {
 	Currency          interface{}            `toml:"currency"`
 	DefaultView       interface{}            `toml:"default_view"`
 	DefaultChartRange interface{}            `toml:"default_chart_range"`
+	MaxTableWidth     interface{}            `toml:"max_table_width"`
+	MaxChartWidth     interface{}            `toml:"max_chart_width"`
 	CoinMarketCap     map[string]interface{} `toml:"coinmarketcap"`
 	API               interface{}            `toml:"api"`
 	Colorscheme       interface{}            `toml:"colorscheme"`
@@ -264,6 +266,8 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 	var currencyIfc interface{} = ct.State.currencyConversion
 	var defaultViewIfc interface{} = ct.State.defaultView
 	var defaultChartRangeIfc interface{} = ct.State.defaultChartRange
+	var maxTableWidth interface{} = ct.maxChartWidth
+	var maxChartWidth interface{} = ct.maxChartWidth
 	var colorschemeIfc interface{} = ct.colorschemeName
 	var refreshRateIfc interface{} = uint(ct.State.refreshRate.Seconds())
 	var cacheDirIfc interface{} = ct.State.cacheDir
@@ -304,6 +308,8 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 		Currency:          currencyIfc,
 		DefaultView:       defaultViewIfc,
 		DefaultChartRange: defaultChartRangeIfc,
+		MaxTableWidth:     maxTableWidth,
+		MaxChartWidth:     maxChartWidth,
 		Favorites:         favoritesMapIfc,
 		RefreshRate:       refreshRateIfc,
 		Shortcuts:         shortcutsIfcs,

--- a/cointop/config.go
+++ b/cointop/config.go
@@ -42,7 +42,6 @@ type ConfigFileConfig struct {
 	Currency          interface{}            `toml:"currency"`
 	DefaultView       interface{}            `toml:"default_view"`
 	DefaultChartRange interface{}            `toml:"default_chart_range"`
-	MaxTableWidth     interface{}            `toml:"max_table_width"`
 	MaxChartWidth     interface{}            `toml:"max_chart_width"`
 	CoinMarketCap     map[string]interface{} `toml:"coinmarketcap"`
 	API               interface{}            `toml:"api"`
@@ -80,7 +79,6 @@ func (ct *Cointop) SetupConfig() error {
 		return err
 	}
 	if err := ct.loadMaxChartWidthFromConfig(); err != nil {
-		log.Debug("SetupConfig() ERR", err)
 		return err
 	}
 	if err := ct.loadAPIKeysFromConfig(); err != nil {
@@ -270,7 +268,6 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 	var currencyIfc interface{} = ct.State.currencyConversion
 	var defaultViewIfc interface{} = ct.State.defaultView
 	var defaultChartRangeIfc interface{} = ct.State.defaultChartRange
-	var maxTableWidth interface{} = ct.maxTableWidth
 	var maxChartWidth interface{} = ct.State.maxChartWidth
 	var colorschemeIfc interface{} = ct.colorschemeName
 	var refreshRateIfc interface{} = uint(ct.State.refreshRate.Seconds())
@@ -312,7 +309,6 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 		Currency:          currencyIfc,
 		DefaultView:       defaultViewIfc,
 		DefaultChartRange: defaultChartRangeIfc,
-		MaxTableWidth:     maxTableWidth,
 		MaxChartWidth:     maxChartWidth,
 		Favorites:         favoritesMapIfc,
 		RefreshRate:       refreshRateIfc,

--- a/cointop/config.go
+++ b/cointop/config.go
@@ -79,6 +79,10 @@ func (ct *Cointop) SetupConfig() error {
 	if err := ct.loadDefaultChartRangeFromConfig(); err != nil {
 		return err
 	}
+	if err := ct.loadMaxChartWidthFromConfig(); err != nil {
+		log.Debug("SetupConfig() ERR", err)
+		return err
+	}
 	if err := ct.loadAPIKeysFromConfig(); err != nil {
 		return err
 	}
@@ -266,8 +270,8 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 	var currencyIfc interface{} = ct.State.currencyConversion
 	var defaultViewIfc interface{} = ct.State.defaultView
 	var defaultChartRangeIfc interface{} = ct.State.defaultChartRange
-	var maxTableWidth interface{} = ct.maxChartWidth
-	var maxChartWidth interface{} = ct.maxChartWidth
+	var maxTableWidth interface{} = ct.maxTableWidth
+	var maxChartWidth interface{} = ct.State.maxChartWidth
 	var colorschemeIfc interface{} = ct.colorschemeName
 	var refreshRateIfc interface{} = uint(ct.State.refreshRate.Seconds())
 	var cacheDirIfc interface{} = ct.State.cacheDir
@@ -428,6 +432,16 @@ func (ct *Cointop) loadDefaultChartRangeFromConfig() error {
 		ct.State.defaultChartRange = defaultChartRange
 		ct.State.selectedChartRange = defaultChartRange
 	}
+	return nil
+}
+
+// loadMaxChartWidthFromConfig loads max chart width from config file to struct
+func (ct *Cointop) loadMaxChartWidthFromConfig() error {
+	log.Debug("loadMaxChartWidthFromConfig()")
+	if maxChartWidth, ok := ct.config.MaxChartWidth.(int64); ok {
+		ct.State.maxChartWidth = int(maxChartWidth)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Configurable max-width for charts, defaults to 175 (current value). Set to 0 for full screen width.