### PR TITLE
Set currency symbol width to rune string width

### DIFF
--- a/cointop/conversion.go
+++ b/cointop/conversion.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cointop-sh/cointop/pkg/color"
 	"github.com/cointop-sh/cointop/pkg/pad"
+	"github.com/mattn/go-runewidth"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -249,7 +250,14 @@ func (ct *Cointop) SetCurrencyConverstionFn(convert string) func() error {
 // CurrencySymbol returns the symbol for the currency conversion
 func (ct *Cointop) CurrencySymbol() string {
 	log.Debug("CurrencySymbol()")
-	return CurrencySymbol(ct.State.currencyConversion)
+	symbol := CurrencySymbol(ct.State.currencyConversion)
+
+	width := runewidth.StringWidth(symbol)
+	if width > 1 {
+		symbol = pad.Right(symbol, width, " ")
+	}
+
+	return symbol
 }
 
 // ShowConvertMenu shows the convert menu view

--- a/cointop/table_header.go
+++ b/cointop/table_header.go
@@ -212,12 +212,7 @@ func (ct *Cointop) UpdateTableHeader() error {
 		leftAlign := ct.GetTableColumnAlignLeft(col)
 		switch col {
 		case "price", "balance":
-			spacing := ""
-			// Add an extra space because "satoshi" UTF-8 chracter overlaps text on right
-			if ct.State.currencyConversion == "SATS" {
-				spacing = " "
-			}
-			label = fmt.Sprintf("%s%s%s", ct.CurrencySymbol(), spacing, label)
+			label = fmt.Sprintf("%s%s", ct.CurrencySymbol(), label)
 		}
 		if leftAlign {
 			label = label + arrow


### PR DESCRIPTION
Fixes the SATS symbol alignment issues with gocui

![DeepinScreenshot_select-area_20211008173131](https://user-images.githubusercontent.com/168240/136637375-6e0753af-79d5-4aeb-ae93-dbd57bd9f042.png)
