### PR TITLE
Add configuration for enable_mouse

### DIFF
--- a/cointop/cointop.go
+++ b/cointop/cointop.go
@@ -92,6 +92,7 @@ type State struct {
 	tableCompactNotation     bool
 	favoritesCompactNotation bool
 	portfolioCompactNotation bool
+	enableMouse              bool
 }
 
 // Cointop cointop
@@ -186,6 +187,9 @@ var DefaultChartRange = "1Y"
 
 // DefaultCompactNotation ...
 var DefaultCompactNotation = false
+
+// DefaultEnableMouse ...
+var DefaultEnableMouse = true
 
 // DefaultMaxChartWidth ...
 var DefaultMaxChartWidth = 175
@@ -296,6 +300,7 @@ func NewCointop(config *Config) (*Cointop, error) {
 				SoundEnabled: true,
 			},
 			compactNotation:          DefaultCompactNotation,
+			enableMouse:              DefaultEnableMouse,
 			tableCompactNotation:     DefaultCompactNotation,
 			favoritesCompactNotation: DefaultCompactNotation,
 			portfolioCompactNotation: DefaultCompactNotation,
@@ -488,7 +493,7 @@ func (ct *Cointop) Run() error {
 	defer ui.Close()
 
 	ui.SetInputEsc(true)
-	ui.SetMouse(true)
+	ui.SetMouse(ct.State.enableMouse)
 	ui.SetHighlight(true)
 	ui.SetManagerFunc(ct.layout)
 	if err := ct.SetKeybindings(); err != nil {

--- a/cointop/config.go
+++ b/cointop/config.go
@@ -49,6 +49,7 @@ type ConfigFileConfig struct {
 	RefreshRate       interface{}            `toml:"refresh_rate"`
 	CacheDir          interface{}            `toml:"cache_dir"`
 	CompactNotation   interface{}            `toml:"compact_notation"`
+	EnableMouse       interface{}            `toml:"enable_mouse"`
 	Table             map[string]interface{} `toml:"table"`
 	Chart             map[string]interface{} `toml:"chart"`
 }
@@ -72,6 +73,7 @@ func (ct *Cointop) SetupConfig() error {
 		ct.loadRefreshRateFromConfig,
 		ct.loadCacheDirFromConfig,
 		ct.loadCompactNotationFromConfig,
+		ct.loadEnableMouseFromConfig,
 		ct.loadPriceAlertsFromConfig,
 		ct.loadPortfolioFromConfig,
 	}
@@ -289,6 +291,7 @@ func (ct *Cointop) ConfigToToml() ([]byte, error) {
 		Table:             tableMapIfc,
 		Chart:             chartMapIfc,
 		CompactNotation:   ct.State.compactNotation,
+		EnableMouse:       ct.State.enableMouse,
 	}
 
 	var b bytes.Buffer
@@ -501,6 +504,16 @@ func (ct *Cointop) loadCompactNotationFromConfig() error {
 	log.Debug("loadCompactNotationFromConfig()")
 	if compactNotation, ok := ct.config.CompactNotation.(bool); ok {
 		ct.State.compactNotation = compactNotation
+	}
+
+	return nil
+}
+
+// loadCompactNotationFromConfig loads compact-notation setting from config file to struct
+func (ct *Cointop) loadEnableMouseFromConfig() error {
+	log.Debug("loadEnableMouseFromConfig()")
+	if enableMouse, ok := ct.config.EnableMouse.(bool); ok {
+		ct.State.enableMouse = enableMouse
 	}
 
 	return nil

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -38,12 +38,12 @@ func (ui *UI) SetBgColor(bgColor gocui.Attribute) {
 
 // SetInputEsc enables the escape key
 func (ui *UI) SetInputEsc(enabled bool) {
-	ui.g.InputEsc = true
+	ui.g.InputEsc = enabled
 }
 
 // SetMouse enables the mouse
 func (ui *UI) SetMouse(enabled bool) {
-	ui.g.Mouse = true
+	ui.g.Mouse = enabled
 }
 
 // SetCursor enables the input field cursor
@@ -53,7 +53,7 @@ func (ui *UI) SetCursor(enabled bool) {
 
 // SetHighlight enables the highlight active state
 func (ui *UI) SetHighlight(enabled bool) {
-	ui.g.Highlight = true
+	ui.g.Highlight = enabled
 }
 
 // SetManagerFunc sets the function to call for rendering UI


### PR DESCRIPTION
Add top-level configuration item enable_mouse for enabling/disabling mouse (defaults to enabled). Fix bug with ui.SetMouse() ignoring the provided setting. See #241 