### PR TITLE
Fixing corrupted coin rank issue when using portfolio coins.

### DIFF
--- a/cointop/coin.go
+++ b/cointop/coin.go
@@ -31,6 +31,34 @@ type Coin struct {
 	BuyCurrency string
 }
 
+// DeepCopy returns a deep copy of a 'Coin' object, making it alright to modify
+// the rank of the coin object without updating the global state.
+func (c *Coin) DeepCopy() *Coin {
+	return &Coin{
+		ID:               c.ID,
+		Name:             c.Name,
+		Slug:             c.Slug,
+		Symbol:           c.Symbol,
+		Rank:             c.Rank,
+		Price:            c.Price,
+		Volume24H:        c.Volume24H,
+		MarketCap:        c.MarketCap,
+		AvailableSupply:  c.AvailableSupply,
+		TotalSupply:      c.TotalSupply,
+		PercentChange1H:  c.PercentChange1H,
+		PercentChange24H: c.PercentChange24H,
+		PercentChange7D:  c.PercentChange7D,
+		PercentChange30D: c.PercentChange30D,
+		PercentChange1Y:  c.PercentChange1Y,
+		LastUpdated:      c.LastUpdated,
+		Favorite:         c.Favorite,
+		Holdings:         c.Holdings,
+		Balance:          c.Balance,
+		BuyPrice:         c.BuyPrice,
+		BuyCurrency:      c.BuyCurrency,
+	}
+}
+
 // AllCoins returns a slice of all the coins
 func (ct *Cointop) AllCoins() []*Coin {
 	log.Debug("AllCoins()")

--- a/cointop/portfolio.go
+++ b/cointop/portfolio.go
@@ -709,11 +709,16 @@ func (ct *Cointop) GetPortfolioSlice() []*Coin {
 
 	for _, p := range ct.State.portfolio.Entries {
 		coinIfc, _ := ct.State.allCoinsSlugMap.Load(p.Coin)
-		coin, ok := coinIfc.(*Coin)
+		originalCoin, ok := coinIfc.(*Coin)
 		if !ok {
 			log.Errorf("Could not find coin %s", p.Coin)
 			continue
 		}
+
+		// making a deep copy should prevent us from corrupting the global map ranking when
+		// we update the Portfolio ranking for coins
+		coin := originalCoin.DeepCopy()
+
 		coin.Holdings = p.Holdings
 		coin.BuyPrice = p.BuyPrice
 		coin.BuyCurrency = p.BuyCurrency


### PR DESCRIPTION
Resolves issue https://github.com/cointop-sh/cointop/issues/322.

Issue: A coin's rank becomes corrupted when the coin is present in the portfolio view. This PR resolves the issue by making a deep copy of coin's for the portfolio view, so the coin rankings in the portfolio view are not written back to the global coin map.